### PR TITLE
Remove assumption of "Tox User" being the default peer name.

### DIFF
--- a/tox_test.go
+++ b/tox_test.go
@@ -633,7 +633,7 @@ func TestGroup(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if len(pname) != len("Tox User") {
+			if len(pname) != 0 {
 				t.Error(pname)
 			}
 			pubkey, err := t1.t.GroupPeerPubkey(gn, 0)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/go-toxcore-c/10)
<!-- Reviewable:end -->
