### PR TITLE
Fix group internals code relying on toxcore internals.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "group_intern_test.go",
         "group_test.go",
         "tox_test.go",
     ],

--- a/group_intern.c
+++ b/group_intern.c
@@ -232,7 +232,7 @@ static Group_c_Fake *get_group_c(Tox *tox, int groupnumber)
     // int fos2 = offsetof(Group_c_Fake, identifier);
     int conferences_object_offset = fos;
 
-    char **p = (char**)(&((char*)tox)[0] + conferences_object_offset);
+    char **p = (char**)(&((char*)*(struct Messenger **)tox)[0] + conferences_object_offset);
     // void *p2 = ((struct Messenger*)tox)->conferences_object;
     Group_Chats* grpchats = (Group_Chats*)(*p);
     if (groupnumber_not_valid(grpchats, groupnumber)) {


### PR DESCRIPTION
These broke with the introduction of struct Tox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/go-toxcore-c/21)
<!-- Reviewable:end -->
