### PR TITLE
Use `(void)` for empty parameter lists in C.

### DIFF
--- a/group.go
+++ b/group.go
@@ -15,7 +15,7 @@ void callbackConferencePeerNameWrapperForC(Tox*, uint32_t, uint32_t, uint8_t*, s
 void callbackConferencePeerListChangedWrapperForC(Tox*, uint32_t, void*);
 
 // fix nouse compile warning
-static inline __attribute__((__unused__)) void fixnousetoxgroup() {
+static inline __attribute__((__unused__)) void fixnousetoxgroup(void) {
 }
 
 */

--- a/tox.go
+++ b/tox.go
@@ -28,7 +28,7 @@ void callbackFileChunkRequestWrapperForC(Tox *tox, uint32_t friend_number, uint3
                                        size_t length, void *user_data);
 
 // fix nouse compile warning
-static inline __attribute__((__unused__)) void fixnousetox() {
+static inline __attribute__((__unused__)) void fixnousetox(void) {
 }
 
 */


### PR DESCRIPTION
Because `()` means "some unknown number of parameters".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/go-toxcore-c/25)
<!-- Reviewable:end -->
