### PR TITLE
[WIP] Reduce cgo call cost

### DIFF
--- a/tox.go
+++ b/tox.go
@@ -38,6 +38,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+
 	// "sync"
 	"unsafe"
 
@@ -797,7 +798,7 @@ func (this *Tox) FriendGetName(friendNumber uint32) (string, error) {
 
 	var cerr C.TOX_ERR_FRIEND_QUERY
 	nlen := C.tox_friend_get_name_size(this.toxcore, _fn, &cerr)
-	_name := make([]byte, nlen)
+	_name := make([]byte, nlen+1)
 
 	r := C.tox_friend_get_name(this.toxcore, _fn, (*C.uint8_t)(safeptr(_name)), &cerr)
 	if !bool(r) {

--- a/tox_papi.c
+++ b/tox_papi.c
@@ -1,0 +1,67 @@
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <tox/tox.h>
+
+
+#define PAPI_PARAM_HEADER uint8_t gosz; Tox* tox;
+#define PAPI_GETCHK_PARAM(stname) stname* prm=(stname*)(void*)params; \
+    if (prm->gosz != sizeof(stname)) {                                  \
+        fprintf(stderr, "gostsz=%d, cstsz=%ld\n", prm->gosz, sizeof(stname)); \
+        assert(prm->gosz == sizeof(stname)); }
+
+typedef struct {
+    PAPI_PARAM_HEADER;
+    uint8_t* addr;
+} self_get_address_param;
+
+void tox_self_get_address_p(uintptr_t params) {
+    PAPI_GETCHK_PARAM(self_get_address_param);
+    tox_self_get_address(prm->tox, prm->addr);
+}
+
+typedef  struct {
+    PAPI_PARAM_HEADER;
+    uint32_t friendNumber;
+    uint8_t* name         ;
+    long error        ;
+    long namelen      ;
+}friend_get_name_param;
+
+bool tox_friend_get_name_p(uintptr_t params) {
+    PAPI_GETCHK_PARAM(friend_get_name_param);
+    prm->namelen = tox_friend_get_name_size(prm->tox, prm->friendNumber, (TOX_ERR_FRIEND_QUERY*)&prm->error);
+    prm->namelen = 100;
+    return tox_friend_get_name(prm->tox, prm->friendNumber, prm->name, (TOX_ERR_FRIEND_QUERY*)&prm->error);
+}
+
+typedef  struct {
+    PAPI_PARAM_HEADER;
+    uint32_t friendNumber;
+    uint8_t* pubkey         ;
+    long error        ;
+}friend_get_public_key_param;
+
+bool tox_friend_get_public_key_p(uintptr_t params) {
+    PAPI_GETCHK_PARAM(friend_get_public_key_param);
+    return tox_friend_get_public_key(prm->tox, prm->friendNumber, prm->pubkey,
+                               (TOX_ERR_FRIEND_GET_PUBLIC_KEY*)&prm->error);
+}
+
+typedef struct {
+    PAPI_PARAM_HEADER;
+    uint32_t friend_number;
+    TOX_MESSAGE_TYPE type;
+    uint8_t* message;
+    size_t length;
+    TOX_ERR_FRIEND_SEND_MESSAGE error;
+} send_message_param;
+
+uint32_t tox_friend_send_message_p(uintptr_t params) {
+    PAPI_GETCHK_PARAM(send_message_param);
+    uint32_t ret = tox_friend_send_message(prm->tox, prm->friend_number, prm->type,
+                                           prm->message, prm->length, &prm->error);
+    return ret;
+}

--- a/tox_papi.c
+++ b/tox_papi.c
@@ -6,10 +6,10 @@
 #include <tox/tox.h>
 
 
-#define PAPI_PARAM_HEADER uint8_t gosz; Tox* tox;
+#define PAPI_PARAM_HEADER uintptr_t gosz; Tox* tox;
 #define PAPI_GETCHK_PARAM(stname) stname* prm=(stname*)(void*)params; \
     if (prm->gosz != sizeof(stname)) {                                  \
-        fprintf(stderr, "gostsz=%d, cstsz=%ld\n", prm->gosz, sizeof(stname)); \
+        fprintf(stderr, "gostsz=%ld, cstsz=%ld\n", prm->gosz, sizeof(stname)); \
         assert(prm->gosz == sizeof(stname)); }
 
 typedef struct {
@@ -24,34 +24,37 @@ void tox_self_get_address_p(uintptr_t params) {
 
 typedef  struct {
     PAPI_PARAM_HEADER;
+    bool retval;
     uint32_t friendNumber;
-    uint8_t* name         ;
+    uint8_t* name     ;
     long error        ;
     long namelen      ;
 }friend_get_name_param;
 
-bool tox_friend_get_name_p(uintptr_t params) {
+void tox_friend_get_name_p(uintptr_t params) {
     PAPI_GETCHK_PARAM(friend_get_name_param);
     prm->namelen = tox_friend_get_name_size(prm->tox, prm->friendNumber, (TOX_ERR_FRIEND_QUERY*)&prm->error);
     prm->namelen = 100;
-    return tox_friend_get_name(prm->tox, prm->friendNumber, prm->name, (TOX_ERR_FRIEND_QUERY*)&prm->error);
+    prm->retval = tox_friend_get_name(prm->tox, prm->friendNumber, prm->name, (TOX_ERR_FRIEND_QUERY*)&prm->error);
 }
 
 typedef  struct {
     PAPI_PARAM_HEADER;
+    bool retval;
     uint32_t friendNumber;
     uint8_t* pubkey         ;
     long error        ;
 }friend_get_public_key_param;
 
-bool tox_friend_get_public_key_p(uintptr_t params) {
+void tox_friend_get_public_key_p(uintptr_t params) {
     PAPI_GETCHK_PARAM(friend_get_public_key_param);
-    return tox_friend_get_public_key(prm->tox, prm->friendNumber, prm->pubkey,
+    prm->retval = tox_friend_get_public_key(prm->tox, prm->friendNumber, prm->pubkey,
                                (TOX_ERR_FRIEND_GET_PUBLIC_KEY*)&prm->error);
 }
 
 typedef struct {
     PAPI_PARAM_HEADER;
+    uint32_t retval;
     uint32_t friend_number;
     TOX_MESSAGE_TYPE type;
     uint8_t* message;
@@ -59,9 +62,8 @@ typedef struct {
     TOX_ERR_FRIEND_SEND_MESSAGE error;
 } send_message_param;
 
-uint32_t tox_friend_send_message_p(uintptr_t params) {
+void tox_friend_send_message_p(uintptr_t params) {
     PAPI_GETCHK_PARAM(send_message_param);
-    uint32_t ret = tox_friend_send_message(prm->tox, prm->friend_number, prm->type,
+    prm->retval = tox_friend_send_message(prm->tox, prm->friend_number, prm->type,
                                            prm->message, prm->length, &prm->error);
-    return ret;
 }

--- a/tox_papi.go
+++ b/tox_papi.go
@@ -1,0 +1,97 @@
+package tox
+
+/*
+#include <stdlib.h>
+#include <string.h>
+
+#include "tox_papi.h"
+
+*/
+import "C"
+import (
+	"encoding/hex"
+	"strings"
+	"unsafe"
+)
+
+type self_get_address_param struct {
+	gosz uint8
+	t    unsafe.Pointer
+	addr *byte
+}
+
+func new_self_get_address_param() *self_get_address_param {
+	this := &self_get_address_param{}
+	this.gosz = uint8(unsafe.Sizeof(*this))
+	return this
+}
+
+func (this *Tox) toxptr() unsafe.Pointer { return unsafe.Pointer(this.toxcore) }
+
+func (this *Tox) SelfGetAddress_p() string {
+	var addr [ADDRESS_SIZE]byte
+	prm := new_self_get_address_param()
+	prm.t = this.toxptr()
+	prm.addr = &addr[0]
+	// log.Println(prm.gosz)
+	// os.Exit(0)
+
+	C.tox_self_get_address_p(C.uintptr_t(uintptr(unsafe.Pointer(prm))))
+
+	return strings.ToUpper(hex.EncodeToString(addr[:]))
+}
+
+type friend_get_name_param struct {
+	gosz         uint8
+	t            unsafe.Pointer
+	friendNumber uint32
+	name         *byte
+	error        int
+	namelen      int
+}
+
+func new_friend_get_name_param() *friend_get_name_param {
+	this := &friend_get_name_param{}
+	this.gosz = uint8(unsafe.Sizeof(*this))
+	return this
+}
+
+func (this *Tox) FriendGetName_p(friendNumber uint32) (string, error) {
+	prm := new_friend_get_name_param()
+	prm.t = this.toxptr()
+	prm.friendNumber = friendNumber
+	var name [MAX_NAME_LENGTH]byte
+	prm.name = &name[0]
+
+	r := C.tox_friend_get_name_p(C.uintptr_t(uintptr(unsafe.Pointer(prm))))
+	if !bool(r) {
+	}
+	return string(name[:prm.namelen]), nil
+}
+
+type friend_get_public_key_param struct {
+	gosz         uint8
+	t            unsafe.Pointer
+	friendNumber uint32
+	pubkey       *byte
+	error        int
+}
+
+func new_friend_get_public_key_param() *friend_get_public_key_param {
+	this := &friend_get_public_key_param{}
+	this.gosz = uint8(unsafe.Sizeof(*this))
+	return this
+}
+
+func (this *Tox) FriendGetPublicKey_p(friendNumber uint32) (string, error) {
+	prm := new_friend_get_public_key_param()
+	prm.t = this.toxptr()
+	prm.friendNumber = friendNumber
+	var pubkey [PUBLIC_KEY_SIZE]byte
+	prm.pubkey = &pubkey[0]
+
+	r := C.tox_friend_get_public_key_p(C.uintptr_t(uintptr(unsafe.Pointer(prm))))
+	if !bool(r) {
+	}
+	return string(pubkey[:PUBLIC_KEY_SIZE]), nil
+}

--- a/tox_papi.go
+++ b/tox_papi.go
@@ -15,14 +15,15 @@ import (
 )
 
 type self_get_address_param struct {
-	gosz uint8
-	t    unsafe.Pointer
-	addr *byte
+	gosz   uintptr
+	t      unsafe.Pointer
+	retval bool
+	addr   *byte
 }
 
 func new_self_get_address_param() *self_get_address_param {
 	this := &self_get_address_param{}
-	this.gosz = uint8(unsafe.Sizeof(*this))
+	this.gosz = uintptr(unsafe.Sizeof(*this))
 	return this
 }
 
@@ -42,8 +43,9 @@ func (this *Tox) SelfGetAddress_p() string {
 }
 
 type friend_get_name_param struct {
-	gosz         uint8
+	gosz         uintptr
 	t            unsafe.Pointer
+	retval       bool
 	friendNumber uint32
 	name         *byte
 	error        int
@@ -52,7 +54,7 @@ type friend_get_name_param struct {
 
 func new_friend_get_name_param() *friend_get_name_param {
 	this := &friend_get_name_param{}
-	this.gosz = uint8(unsafe.Sizeof(*this))
+	this.gosz = uintptr(unsafe.Sizeof(*this))
 	return this
 }
 
@@ -63,15 +65,17 @@ func (this *Tox) FriendGetName_p(friendNumber uint32) (string, error) {
 	var name [MAX_NAME_LENGTH]byte
 	prm.name = &name[0]
 
-	r := C.tox_friend_get_name_p(C.uintptr_t(uintptr(unsafe.Pointer(prm))))
-	if !bool(r) {
+	C.tox_friend_get_name_p(C.uintptr_t(uintptr(unsafe.Pointer(prm))))
+	if !prm.retval {
+		// error
 	}
 	return string(name[:prm.namelen]), nil
 }
 
 type friend_get_public_key_param struct {
-	gosz         uint8
+	gosz         uintptr
 	t            unsafe.Pointer
+	retval       bool
 	friendNumber uint32
 	pubkey       *byte
 	error        int
@@ -79,7 +83,7 @@ type friend_get_public_key_param struct {
 
 func new_friend_get_public_key_param() *friend_get_public_key_param {
 	this := &friend_get_public_key_param{}
-	this.gosz = uint8(unsafe.Sizeof(*this))
+	this.gosz = uintptr(unsafe.Sizeof(*this))
 	return this
 }
 
@@ -90,8 +94,9 @@ func (this *Tox) FriendGetPublicKey_p(friendNumber uint32) (string, error) {
 	var pubkey [PUBLIC_KEY_SIZE]byte
 	prm.pubkey = &pubkey[0]
 
-	r := C.tox_friend_get_public_key_p(C.uintptr_t(uintptr(unsafe.Pointer(prm))))
-	if !bool(r) {
+	C.tox_friend_get_public_key_p(C.uintptr_t(uintptr(unsafe.Pointer(prm))))
+	if !prm.retval {
+		// error
 	}
 	return string(pubkey[:PUBLIC_KEY_SIZE]), nil
 }

--- a/tox_papi.h
+++ b/tox_papi.h
@@ -5,9 +5,9 @@
 #include <tox/tox.h>
 
 extern void tox_self_get_address_p(uintptr_t params);
-extern bool tox_friend_get_name_p(uintptr_t params);
-extern bool tox_friend_get_public_key_p(uintptr_t params);
-extern uint32_t tox_friend_send_message_p(uintptr_t params);
+extern void tox_friend_get_name_p(uintptr_t params);
+extern void tox_friend_get_public_key_p(uintptr_t params);
+extern void tox_friend_send_message_p(uintptr_t params);
 
 #endif
 

--- a/tox_papi.h
+++ b/tox_papi.h
@@ -1,0 +1,14 @@
+#ifndef _TOX_PAPI_H_
+#define _TOX_PAPI_H_
+
+#include <stdint.h>
+#include <tox/tox.h>
+
+extern void tox_self_get_address_p(uintptr_t params);
+extern bool tox_friend_get_name_p(uintptr_t params);
+extern bool tox_friend_get_public_key_p(uintptr_t params);
+extern uint32_t tox_friend_send_message_p(uintptr_t params);
+
+#endif
+
+


### PR DESCRIPTION
CGO call check pointer parameters dynamically, so there are some cost, the more pointer parameters passed, the more cost.

This PR try reduce cgo call cost by pack parameters in a struct both in C and go side, then there are no pointer parameter.

Current change is just for show the idea, not the final code.

This is the benchmark:
```
self_get_address api :   100000 68.895041ms 688ns
self_get_address papi :  100000 61.141223ms 611ns
friend_get_name api :    100000 48.359705ms 483ns
friend_get_name papi :   100000 20.091366ms 200ns                                                                                 
friend_get_pkey api :    100000 45.134832ms 451ns                                                                                 
friend_get_pkey papi :   100000 10.793025ms 107ns
```

Suggestion is welcome both for performance and code organization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/go-toxcore-c/30)
<!-- Reviewable:end -->
