### PR TITLE
Typo fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ The golang bindings for libtoxcore
     // use custom options
     opt := tox.NewToxOptions()
     t := tox.NewTox(opt)
-    av := tox.NewToxAv(t)
+    av := tox.NewToxAV(t)
     
     // use default options
     t := tox.NewTox(nil)
-    av := tox.NewToxAv(t)
+    av := tox.NewToxAV(t)
 
 ### Tests
 


### PR DESCRIPTION
a typo in the function call NewToxAV fixed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/go-toxcore-c/50)
<!-- Reviewable:end -->
